### PR TITLE
[이달의 차트] 더보기 기능 / 리사이즈에 따른 페이지수

### DIFF
--- a/src/components/ThisMonthsChart.jsx
+++ b/src/components/ThisMonthsChart.jsx
@@ -1,13 +1,40 @@
-import React, { useState } from 'react';
-import './ThisMonthsChart.css';
-import IdolDetail from './IdolDetail';
-import ChartVoteModal from './ChartVoteModal';
-import useIdolChart from '../hooks/useIdolChart';
+import React, { useState, useEffect } from "react";
+import "./ThisMonthsChart.css";
+import IdolDetail from "./IdolDetail";
+import ChartVoteModal from "./ChartVoteModal";
+import useIdolChart from "../hooks/useIdolChart";
+
+const getPageSize = () => {
+  const width = window.innerWidth;
+  if (width < 1200) {
+    return 5;
+  } else {
+    return 10;
+  }
+};
 
 function ThisMonthsChart() {
-  const [activeTab, setActiveTab] = useState('female');
-  const { idolRank, loading, fetchError } = useIdolChart(activeTab);
+  const [activeTab, setActiveTab] = useState("female");
+  const [pageSize, setPageSize] = useState(getPageSize());
+  const { idolRank, loading, fetchError, fetchData } = useIdolChart(
+    activeTab,
+    pageSize
+  );
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [displayCount, setDisplayCount] = useState(pageSize);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const newPageSize = getPageSize();
+      setPageSize(newPageSize);
+      setDisplayCount(newPageSize);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
 
   const openGenderVoteModal = () => {
     setIsModalOpen(true);
@@ -19,13 +46,24 @@ function ThisMonthsChart() {
 
   const tab = (gender) => {
     setActiveTab(gender);
+    setDisplayCount(pageSize); // 탭 변경 시 초기 표시 수로 리셋
+    fetchData(gender, pageSize); // 새로운 데이터 가져오기
+  };
+
+  const loadMore = () => {
+    setDisplayCount((prevCount) => prevCount + pageSize);
   };
 
   return (
     <div className="chart">
       <div className="chart-header">
         <h3>이달의 차트</h3>
-        <button type="button" aria-label="차트 투표하기" className="btn-modal-open" onClick={openGenderVoteModal}>
+        <button
+          type="button"
+          aria-label="차트 투표하기"
+          className="btn-modal-open"
+          onClick={openGenderVoteModal}
+        >
           <i className="icon-chart" />
           차트 투표하기
         </button>
@@ -33,15 +71,15 @@ function ThisMonthsChart() {
       <div className="chart-tab">
         <button
           type="button"
-          className={`chart-tab-button ${activeTab === 'female' ? 'active' : ''}`}
-          onClick={() => tab('female')}
+          className={`chart-tab-button ${activeTab === "female" ? "active" : ""}`}
+          onClick={() => tab("female")}
         >
           이달의 여자 아이돌
         </button>
         <button
           type="button"
-          className={`chart-tab-button ${activeTab === 'male' ? 'active' : ''}`}
-          onClick={() => tab('male')}
+          className={`chart-tab-button ${activeTab === "male" ? "active" : ""}`}
+          onClick={() => tab("male")}
         >
           이달의 남자 아이돌
         </button>
@@ -49,21 +87,38 @@ function ThisMonthsChart() {
       <ul className="ranking-list">
         {loading && <div>Loading...</div>}
         {fetchError && <div>Error loading data</div>}
-        {idolRank.map((idol) => (
-          <IdolDetail
-            key={idol.id}
-            profilePicture={idol.profilePicture}
-            rank={idol.rank}
-            group={idol.group}
-            name={idol.name}
-            totalVotes={idol.totalVotes}
-          />
-        ))}
+        {!loading &&
+          !fetchError &&
+          idolRank
+            .slice(0, displayCount)
+            .map((idol) => (
+              <IdolDetail
+                key={idol.id}
+                profilePicture={idol.profilePicture}
+                rank={idol.rank}
+                group={idol.group}
+                name={idol.name}
+                totalVotes={idol.totalVotes}
+              />
+            ))}
       </ul>
-      <button className="btn-more" type="button" aria-label="더보기 버튼">
-        더 보기
-      </button>
-      {isModalOpen && <ChartVoteModal closeModal={closeModal} idolRank={idolRank} gender={activeTab} />}
+      {displayCount < idolRank.length && (
+        <button
+          className="btn-more"
+          type="button"
+          aria-label="더보기 버튼"
+          onClick={loadMore}
+        >
+          더 보기
+        </button>
+      )}
+      {isModalOpen && (
+        <ChartVoteModal
+          closeModal={closeModal}
+          idolRank={idolRank}
+          gender={activeTab}
+        />
+      )}
     </div>
   );
 }

--- a/src/hooks/useIdolChart.js
+++ b/src/hooks/useIdolChart.js
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import getIdolChart from '../service/idolApi';
+import { useState, useEffect } from "react";
+import getIdolChart from "../service/idolApi";
 
 const useIdolChart = (gender) => {
   const [idolRank, setIdolRank] = useState([]);

--- a/src/service/idolApi.js
+++ b/src/service/idolApi.js
@@ -1,9 +1,7 @@
-const BASE_URL = 'https://fandom-k-api.vercel.app/8-3';
+const BASE_URL = "https://fandom-k-api.vercel.app/8-3";
 
-export default async function getIdolChart(gender = 'female') {
-  const LIMIT = 10;
-  const url = `${BASE_URL}/charts/gender?gender=${gender}&pageSize=${LIMIT}`;
-
+export default async function getIdolChart(gender = "female", pageSize = 10) {
+  const url = `${BASE_URL}/charts/gender?gender=${gender}&pageSize=${pageSize}`;
   try {
     const response = await fetch(url);
 
@@ -12,7 +10,7 @@ export default async function getIdolChart(gender = 'female') {
     }
     const result = await response.json();
     const data = result.idols;
-
+    console.log(data);
     return data;
   } catch (error) {
     return [];


### PR DESCRIPTION
# PR
- 더보기 버튼을 누르면 해당 리사이즈 리턴 값만큼 아이돌리스트 불러오기
- 리사이즈 1200 이하면 5개만 보이게 하기

# 특별히 봐줬으면 하는 부분
- 해당 랭킹 맴버가 10명 밖에 없어서 화면이 1200px이상에서는 더보기 버튼 안보임 / 샘플링 작업 20명 정도 목데이터 만들어야 더보기 버튼이 활성화 됨.
- 테스트를 하고 싶으면 1200px 이하 사이즈에서 더보기 버튼 확인 바람

# 스크린샷
<img width="296" alt="image" src="https://github.com/user-attachments/assets/864cff41-eb6f-4ac6-8f15-46cbb00f02ce">